### PR TITLE
update emitter methods

### DIFF
--- a/ios/RCTTwilio/RCTTwilio.h
+++ b/ios/RCTTwilio/RCTTwilio.h
@@ -6,9 +6,9 @@
 //  Copyright © 2015 Rogchap Software. All rights reserved.
 //
 
-#import <RCTBridge.h>
+#import "RCTBridgeModule.h"
 #import "TwilioClient.h"
+#import "RCTEventEmitter.h"
 
-@interface RCTTwilio : NSObject <RCTBridgeModule, TCDeviceDelegate, TCConnectionDelegate>
-
+@interface RCTTwilio : RCTEventEmitter <RCTBridgeModule, TCDeviceDelegate, TCConnectionDelegate>
 @end

--- a/ios/RCTTwilio/RCTTwilio.m
+++ b/ios/RCTTwilio/RCTTwilio.m
@@ -6,116 +6,125 @@
 //  Copyright © 2015 Rogchap Software. All rights reserved.
 //
 
-#import "RCTTwilio.h"
 #import "RCTEventDispatcher.h"
+#import "RCTTwilio.h"
+#import "RCTEventEmitter.h"
 
-@implementation RCTTwilio {
-    TCDevice* _phone;
-    TCConnection* _connection;
-    TCConnection* _pendingConnection;
+NSString *const deviceDidReceiveIncoming = @"RCTTwilio/deviceDidReceiveIncoming";
+NSString *const deviceDidStartListening = @"RCTTwilio/deviceDidStartListening";
+NSString *const deviceDidStopListening = @"RCTTwilio/deviceDidStopListening";
+NSString *const connectionDidFail = @"RCTTwilio/connectionDidFail";
+NSString *const connectionDidStartConnecting = @"RCTTwilio/connectionDidStartConnecting";
+NSString *const connectionDidConnect = @"RCTTwilio/connectionDidConnect";
+NSString *const connectionDidDisconnect = @"RCTTwilio/connectionDidDisconnect";
+
+@implementation RCTTwilio
+{
+  TCDevice* _phone;
+  TCConnection* _connection;
+  TCConnection* _pendingConnection;
 }
 
 RCT_EXPORT_MODULE();
 
 @synthesize bridge = _bridge;
 
+- (NSArray<NSString *> *)supportedEvents {
+  return @[deviceDidReceiveIncoming, deviceDidStartListening, deviceDidStopListening, connectionDidFail, connectionDidStartConnecting, connectionDidConnect, connectionDidDisconnect];
+}
+
 RCT_EXPORT_METHOD(initWithTokenUrl:(NSString *) tokenUrl) {
-    NSURL *url = [NSURL URLWithString: tokenUrl];
-    NSError *error = nil;
-    NSString *token = [NSString stringWithContentsOfURL:url encoding:NSUTF8StringEncoding error:&error];
-    if (token == nil) {
-        NSLog(@"Error retrieving token: %@", [error localizedDescription]);
-    } else {
-        _phone = [[TCDevice alloc] initWithCapabilityToken:token delegate:self];
-    }
+  NSURL *url = [NSURL URLWithString: tokenUrl];
+  NSError *error = nil;
+  NSString *token = [NSString stringWithContentsOfURL:url encoding:NSUTF8StringEncoding error:&error];
+  if (token == nil) {
+    NSLog(@"Error retrieving token: %@", [error localizedDescription]);
+  } else {
+    _phone = [[TCDevice alloc] initWithCapabilityToken:token delegate:self];
+  }
 }
 
 RCT_EXPORT_METHOD(initWithToken:(NSString *) token) {
-    _phone = [[TCDevice alloc] initWithCapabilityToken:token delegate:self];
+  _phone = [[TCDevice alloc] initWithCapabilityToken:token delegate:self];
 }
 
 RCT_EXPORT_METHOD(connect:(NSDictionary *) params) {
-    _connection = [_phone connect:params delegate:self];
+  _connection = [_phone connect:params delegate:self];
 }
 
 RCT_EXPORT_METHOD(disconnect) {
-    [_connection disconnect];
+  [_connection disconnect];
 }
 
 RCT_EXPORT_METHOD(accept) {
-    [_pendingConnection accept];
-    _connection = _pendingConnection;
-    _pendingConnection = nil;
+  [_pendingConnection accept];
+  _connection = _pendingConnection;
+  _pendingConnection = nil;
 }
 
 RCT_EXPORT_METHOD(reject) {
-    [_pendingConnection reject];
+  [_pendingConnection reject];
 }
 
 RCT_EXPORT_METHOD(ignore) {
-    [_pendingConnection ignore];
+  [_pendingConnection ignore];
 }
 
 RCT_EXPORT_METHOD(setMuted:(BOOL)isMuted) {
-    if (_connection && _connection.state == TCConnectionStateConnected) {
-        [_connection setMuted:isMuted];
-    }
+  if (_connection && _connection.state == TCConnectionStateConnected) {
+    [_connection setMuted:isMuted];
+  }
 }
 
 RCT_EXPORT_METHOD(sendDigits:(NSString *) digits) {
-    if (_connection && _connection.state == TCConnectionStateConnected) {
-        [_connection sendDigits:digits];
-    }
+  if (_connection && _connection.state == TCConnectionStateConnected) {
+    [_connection sendDigits:digits];
+  }
 }
 
 #pragma mark - TCDeviceDelegate
 
 -(void)device:(TCDevice *)device didReceiveIncomingConnection:(TCConnection *)connection {
-    _pendingConnection = connection;
-    [_pendingConnection setDelegate:self];
-    [self.bridge.eventDispatcher sendAppEventWithName:@"deviceDidReceiveIncoming" body:connection.parameters];
+  _pendingConnection = connection;
+  [_pendingConnection setDelegate:self];
+  [self sendEventWithName:@"deviceDidReceiveIncoming" body:connection.parameters];
 }
 
 -(void)deviceDidStartListeningForIncomingConnections:(TCDevice*)device {
-    [self.bridge.eventDispatcher sendAppEventWithName:@"deviceDidStartListening" body:nil];
+  [self sendEventWithName:@"deviceDidStartListening" body:nil];
 }
 
 -(void)device:(TCDevice *)device didStopListeningForIncomingConnections:(NSError *)error {
-    id body = nil;
-    if (error != nil) {
-        body = @{@"err": [error localizedDescription]};
-    }
-    [self.bridge.eventDispatcher
-     sendAppEventWithName:@"deviceDidStopListening" body:body];
+  id body = nil;
+  if (error != nil) {
+    body = @{@"err": [error localizedDescription]};
+  }
+  [self sendEventWithName:@"deviceDidStopListening" body:body];
 }
 
 #pragma mark - TCConnectionDelegate
 
 -(void)connection:(TCConnection *)connection didFailWithError:(NSError *)error {
-    [self.bridge.eventDispatcher
-     sendAppEventWithName:@"connectionDidFail" body:@{@"err": [error localizedDescription]}];
+  [self sendEventWithName:@"connectionDidFail" body:@{@"err": [error localizedDescription]}];
 }
 
 -(void)connectionDidStartConnecting:(TCConnection *)connection {
-    [self.bridge.eventDispatcher
-     sendAppEventWithName:@"connectionDidStartConnecting" body:connection.parameters];
+  [self sendEventWithName:@"connectionDidStartConnecting" body:connection.parameters];
 }
 
 -(void)connectionDidConnect:(TCConnection *)connection {
-    [self.bridge.eventDispatcher
-     sendAppEventWithName:@"connectionDidConnect" body:nil];
+  [self sendEventWithName:@"connectionDidConnect" body:nil];
 }
 
 -(void)connectionDidDisconnect:(TCConnection *)connection {
-    if (connection == _connection) {
-        _connection = nil;
-    }
-
-    if (connection == _pendingConnection) {
-        _pendingConnection = nil;
-    }
-    [self.bridge.eventDispatcher
-     sendAppEventWithName:@"connectionDidDisconnect" body:nil];
+  if (connection == _connection) {
+    _connection = nil;
+  }
+  
+  if (connection == _pendingConnection) {
+    _pendingConnection = nil;
+  }
+  [self sendEventWithName:@"connectionDidDisconnect" body:nil];
 }
 
 @end


### PR DESCRIPTION
Newer version of RN are going to deprecate the `sendAppEventWithName` method and instead are recommending using the RCTEventEmitter `sendEventWithName` method. I've implemented this in a personal project and it's working great. Let me know if you think this is a good idea. Thanks for the great project, it really helped me out.
